### PR TITLE
Config service typos

### DIFF
--- a/centreonapi/centreon.py
+++ b/centreonapi/centreon.py
@@ -3,11 +3,11 @@
 from centreonapi.webservice.configuration.host import *
 from centreonapi.webservice.configuration.poller import Poller
 from centreonapi.webservice.configuration.hostgroups import Hostgroups
+from centreonapi.webservice.configuration.service import Service, ServiceObject
 from centreonapi.webservice.configuration.templates import Templates
 
 
 class Centreon(object):
-
     def __init__(self, url=None, username=None, password=None):
         Webservice.getInstance(
             url,
@@ -16,13 +16,15 @@ class Centreon(object):
         )
 
         self.host = Host()
-        self.poller = Poller()
         self.hostgroups = Hostgroups()
+        self.poller = Poller()
+        self.service = Service()
         self.templates = Templates()
 
         self.availableHost = None
         self.availableHostGroups = None
         self.availablePoller = None
+        self.availableServices = None
         self.availableTemplates = None
 
     def get_available_object(self):
@@ -30,6 +32,7 @@ class Centreon(object):
             self.availableHost = self.host.list()
             self.availableHostGroups = self.hostgroups.list()
             self.availablePoller = self.poller.list()
+            self.availableServices = self.service.list()
             self.availableHostTemplates = self.templates.list()
         except Exception as exc:
             raise exc
@@ -61,8 +64,23 @@ class Centreon(object):
             self.get_available_object()
         return self._exists(name, self.availableHostTemplates)
 
+    def exists_service(self, name, hostname=None):
+        if self.availableServices is None:
+            self.get_available_object()
+        if hostname is not None:
+            services = [service.servicename() for service in self.service_list() if service.hostname() == hostname]
+        else:
+            services = [service.servicename() for service in self.service_list()]
+        return name in services
+
     def host_list(self):
         list_host = list()
         for host in self.availableHost['result']:
             list_host.append(HostObj(host))
         return list_host
+
+    def service_list(self):
+        list_service = list()
+        for service in self.availableServices['result']:
+            list_service.append(ServiceObj(service))
+        return list

--- a/centreonapi/webservice/configuration/service.py
+++ b/centreonapi/webservice/configuration/service.py
@@ -33,7 +33,7 @@ class Service(object):
     def delhost(self):
         pass
 
-    def getmaro(self, hostname, servicename):
+    def getmacro(self, hostname, servicename):
         return self.webservice.call_clapi('getmacro', 'SERVICE', [hostname,servicename])
 
     def setmacro(self, hostname, servicename, name, value, description):

--- a/centreonapi/webservice/configuration/service.py
+++ b/centreonapi/webservice/configuration/service.py
@@ -102,7 +102,7 @@ class Service(object):
         values = [hostname, servicename, '|'.join(trap)]
         return self.webservice.call_clapi('settrap', 'SERVICE', values)
 
-    def delcontact(self, hostname, servicename, trap):
+    def deltrap(self, hostname, servicename, trap):
         try:
             for i in trap:
                 values = [hostname, servicename, i]

--- a/centreonapi/webservice/configuration/service.py
+++ b/centreonapi/webservice/configuration/service.py
@@ -2,6 +2,52 @@
 
 from centreonapi.webservice import Webservice
 
+
+class ServiceObject(object):
+
+    def __init__(self, properties):
+        self.hostname = properties['host name']
+        self.servicename = properties['description']
+        self.check_command = properties['check command']
+        self.check_command_arg = properties['check command arg']
+        self.normal_check_interval = properties['normal check interval']
+        self.retry_check_interval = properties['retry check interval']
+        self.max_check_attempts = properties['max check attempts']
+        self.active_checks_enabled = properties['active checks enabled']
+        self.passive_checks_enabled = properties['passive checks enabled']
+        self.state = properties['activate']
+
+    def hostname(self):
+        return self.hostname
+
+    def servicename(self):
+        return self.servicename
+
+    def check_command(self):
+        return self.check_command
+
+    def check_command_arg(self):
+        return self.check_command_arg
+
+    def normal_check_interval(self):
+        return self.normal_check_interval
+
+    def retry_check_interval(self):
+        return self.retry_check_interval
+
+    def max_check_attempts(self):
+        return self.max_check_attempts
+
+    def active_checks_enabled(self):
+        return self.active_checks_enabled
+
+    def passive_checks_enabled(self):
+        return self.passive_checks_enabled
+
+    def state(self):
+        return self.state
+
+
 class Service(object):
     """
     Centreon Web Service Object
@@ -18,7 +64,8 @@ class Service(object):
         return self.webservice.call_clapi('add', 'SERVICE', values)
 
     def delete(self, hostname, servicename):
-        return self.webservice.call_clapi('del', 'SERVICE', [hostname, servicename])
+        values = [hostname, servicename]
+        return self.webservice.call_clapi('del', 'SERVICE', values)
 
     def setparam(self, hostname, servicename, name, value):
         values = [hostname, servicename, name, value]
@@ -34,18 +81,19 @@ class Service(object):
         pass
 
     def getmacro(self, hostname, servicename):
-        return self.webservice.call_clapi('getmacro', 'SERVICE', [hostname,servicename])
+        values = [hostname, servicename]
+        return self.webservice.call_clapi('getmacro', 'SERVICE', values)
 
     def setmacro(self, hostname, servicename, name, value, description):
         values = [hostname, servicename, name, value, description]
         return self.webservice.call_clapi('setmacro', 'SERVICE', values)
 
     def delmacro(self, hostname, servicename, name):
-        values = [hostname, servicename, name ]
+        values = [hostname, servicename, name]
         return self.webservice.call_clapi('delmacro', 'SERVICE', values)
 
     def setseverity(self, hostname, servicename, name):
-        values = [hostname, servicename, name ]
+        values = [hostname, servicename, name]
         return self.webservice.call_clapi('setseverity', 'SERVICE', values)
 
     def unsetseverity(self, hostname, servicename):

--- a/centreonapi/webservice/configuration/service.py
+++ b/centreonapi/webservice/configuration/service.py
@@ -73,8 +73,7 @@ class Service(object):
         except Exception:
             return False
 
-
-    def getcontactgrup(self, hostname, servicename):
+    def getcontactgroup(self, hostname, servicename):
         values = [hostname, servicename]
         return self.webservice.call_clapi('getcontactgroup', 'SERVICE', values)
 


### PR DESCRIPTION
PR to fix issues #4, #5 and #6.

Fix typo in various methods name :
- Rename getmaro to getmacro
- Rename getcontactgrup to getcontactgroup
- Rename delcontact to deltrap