### PR TITLE
Support for host templates and service templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-# IntelliJ project files
+## IntelliJ project files
 .idea/
+
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/centreonapi/centreon.py
+++ b/centreonapi/centreon.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from centreonapi.webservice.configuration.host import *
+from centreonapi.webservice.configuration.host_template import *
 from centreonapi.webservice.configuration.poller import Poller
 from centreonapi.webservice.configuration.hostgroups import Hostgroups
-from centreonapi.webservice.configuration.templates import Templates
 from centreonapi.webservice.configuration.commands import Commands
 
 class Centreon(object):
@@ -16,9 +16,9 @@ class Centreon(object):
         )
 
         self.host = Host()
+        self.host_template = HostTemplate()
         self.poller = Poller()
         self.hostgroups = Hostgroups()
-        self.templates = Templates()
         self.commands = Commands()
 
         self.availableHost = None
@@ -32,7 +32,7 @@ class Centreon(object):
             self.availableHost = self.host.list()
             self.availableHostGroups = self.hostgroups.list()
             self.availablePoller = self.poller.list()
-            self.availableHostTemplates = self.templates.list()
+            self.availableHostTemplates = self.host_template.list()
             self.availableCommands = self.commands.list()
         except Exception as exc:
             raise exc

--- a/centreonapi/centreon.py
+++ b/centreonapi/centreon.py
@@ -2,6 +2,7 @@
 
 from centreonapi.webservice.configuration.host import *
 from centreonapi.webservice.configuration.host_template import *
+from centreonapi.webservice.configuration.service_template import *
 from centreonapi.webservice.configuration.poller import Poller
 from centreonapi.webservice.configuration.hostgroups import Hostgroups
 from centreonapi.webservice.configuration.commands import Commands
@@ -17,6 +18,7 @@ class Centreon(object):
 
         self.host = Host()
         self.host_template = HostTemplate()
+        self.service_template = ServiceTemplate()
         self.poller = Poller()
         self.hostgroups = Hostgroups()
         self.commands = Commands()

--- a/centreonapi/webservice/configuration/host.py
+++ b/centreonapi/webservice/configuration/host.py
@@ -33,12 +33,23 @@ class Host(object):
         Constructor
         """
         self.webservice = Webservice.getInstance()
+        self.clapi_object = 'HOST'
 
     def list(self):
         """
         List hosts
         """
-        return self.webservice.call_clapi('show', 'HOST')
+        return self.webservice.call_clapi('show', self.clapi_object)
+
+    def show(self, hostname):
+        values = [hostname]
+        return self.webservice.call_clapi('show', self.clapi_object, values)
+
+    def get(self, hostname):
+        list_host = self.show(hostname)
+        for host in list_host['result']:
+            if hostname == host['name']:
+                return HostObj(host)
 
     def add(self, hostname, hostalias, hostip, hosttemplate, pollername, hgname):
         """
@@ -52,116 +63,113 @@ class Host(object):
             pollername,
             '|'.join(hgname)
         ]
-        return self.webservice.call_clapi('add', 'HOST', values)
+        return self.webservice.call_clapi('add', self.clapi_object, values)
 
     def delete(self, hostname):
-        return self.webservice.call_clapi('del', 'HOST', hostname)
+        return self.webservice.call_clapi('del', self.clapi_object, hostname)
 
     def setparameters(self, hostname, name, value):
         """
-        DEPRECATED 
+        DEPRECATED
         """
         return self.setparam(hostname, name, value)
 
     def setparam(self, hostname, name, value):
         values = [hostname, name, value]
-        return self.webservice.call_clapi('setparam', 'HOST', values)
+        return self.webservice.call_clapi('setparam', self.clapi_object, values)
 
     def setinstance(self, hostname, instance):
         values = [hostname, instance]
-        return self.webservice.call_clapi('setinstance', 'HOST', values)
+        return self.webservice.call_clapi('setinstance', self.clapi_object, values)
 
     def getmacro(self, hostname):
-        return self.webservice.call_clapi('getmacro', 'HOST', hostname)
+        return self.webservice.call_clapi('getmacro', self.clapi_object, hostname)
 
     def setmacro(self, hostname, name, value):
         values = [hostname, name, value]
-        return self.webservice.call_clapi('setmacro', 'HOST', values)
+        return self.webservice.call_clapi('setmacro', self.clapi_object, values)
 
     def deletemacro(self, hostname, name):
         values = [hostname, name]
-        return self.webservice.call_clapi('delmacro', 'HOST', values)
+        return self.webservice.call_clapi('delmacro', self.clapi_object, values)
 
     def gettemplate(self, hostname):
-        return self.webservice.call_clapi('gettemplate', 'HOST', hostname)
+        return self.webservice.call_clapi('gettemplate', self.clapi_object, hostname)
 
     def settemplate(self, hostname, template):
         values = [hostname, "|".join(template)]
-        return self.webservice.call_clapi('settemplate', 'HOST', values)
+        return self.webservice.call_clapi('settemplate', self.clapi_object, values)
 
     def addtemplate(self, hostname, template):
         values = [hostname, "|".join(template)]
-        return self.webservice.call_clapi('addtemplate', 'HOST', values)
+        return self.webservice.call_clapi('addtemplate', self.clapi_object, values)
 
     def deletetemplate(self, hostname, template):
         values = [hostname, "|".join(template)]
-        return self.webservice.call_clapi('delemplate', 'HOST', values)
+        return self.webservice.call_clapi('delemplate', self.clapi_object, values)
 
     def applytemplate(self, hostname):
         """
         Apply the host template to the host, deploy services
         """
-        return self.webservice.call_clapi('applytpl', 'HOST', hostname)
+        return self.webservice.call_clapi('applytpl', self.clapi_object, hostname)
 
     def getparent(self, hostname):
-        return self.webservice.call_clapi('getparent', 'HOST', hostname)
+        return self.webservice.call_clapi('getparent', self.clapi_object, hostname)
 
     def addparent(self, hostname, parents):
-        return self.webservice.call_clapi('addparent', 'HOST', [hostname, "|".join(parents)])
+        return self.webservice.call_clapi('addparent', self.clapi_object, [hostname, "|".join(parents)])
 
     def setparent(self, hostname, parents):
-        return self.webservice.call_clapi('setparent', 'HOST', [hostname, "|".join(parents)])
+        return self.webservice.call_clapi('setparent', self.clapi_object, [hostname, "|".join(parents)])
 
     def deleteparent(self, hostname, parents):
-        return self.webservice.call_clapi('delparent', 'HOST', [hostname, "|".join(parents)])
+        return self.webservice.call_clapi('delparent', self.clapi_object, [hostname, "|".join(parents)])
 
     def getcontactgroup(self, hostname):
-        return self.webservice.call_clapi('getcontactgroup', 'HOST', hostname)
+        return self.webservice.call_clapi('getcontactgroup', self.clapi_object, hostname)
 
     def addcontactgroup(self, hostname, contactgroups):
-        return self.webservice.call_clapi('addcontactgroup', 'HOST', [hostname, "|".join(contactgroups)])
+        return self.webservice.call_clapi('addcontactgroup', self.clapi_object, [hostname, "|".join(contactgroups)])
 
     def setcontactgroup(self, hostname, contactgroups):
-        return self.webservice.call_clapi('setcontactgroup', 'HOST', [hostname, "|".join(contactgroups)])
+        return self.webservice.call_clapi('setcontactgroup', self.clapi_object, [hostname, "|".join(contactgroups)])
 
     def deletecontactgroup(self, hostname, contactgroups):
-        return self.webservice.call_clapi('delcontactgroup', 'HOST', [hostname, "|".join(contactgroups)])
+        return self.webservice.call_clapi('delcontactgroup', self.clapi_object, [hostname, "|".join(contactgroups)])
 
     def getcontact(self, hostname):
-        return self.webservice.call_clapi('getcontact', 'HOST', hostname)
+        return self.webservice.call_clapi('getcontact', self.clapi_object, hostname)
 
     def addcontact(self, hostname, contacts):
-        return self.webservice.call_clapi('addcontact', 'HOST', [hostname, "|".join(contacts)])
+        return self.webservice.call_clapi('addcontact', self.clapi_object, [hostname, "|".join(contacts)])
 
     def setcontact(self, hostname, contacts):
-        return self.webservice.call_clapi('setcontact', 'HOST', [hostname, "|".join(contacts)])
+        return self.webservice.call_clapi('setcontact', self.clapi_object, [hostname, "|".join(contacts)])
 
     def deletecontact(self, hostname, contacts):
-        return self.webservice.call_clapi('delcontact', 'HOST', [hostname, "|".join(contacts)])
+        return self.webservice.call_clapi('delcontact', self.clapi_object, [hostname, "|".join(contacts)])
 
     def gethostgroup(self, hostname):
-        return self.webservice.call_clapi('gethostgroup', 'HOST', hostname)
+        return self.webservice.call_clapi('gethostgroup', self.clapi_object, hostname)
 
     def addhostgroup(self, hostname, hostgroups):
-        return self.webservice.call_clapi('addhostgroup', 'HOST', [hostname, "|".join(hostgroups)])
+        return self.webservice.call_clapi('addhostgroup', self.clapi_object, [hostname, "|".join(hostgroups)])
 
     def sethostgroup(self, hostname, hostgroups):
-        return self.webservice.call_clapi('sethostgroup', 'HOST', [hostname, "|".join(hostgroups)])
+        return self.webservice.call_clapi('sethostgroup', self.clapi_object, [hostname, "|".join(hostgroups)])
 
     def deletehostgroup(self, hostname, hostgroups):
-        return self.webservice.call_clapi('delhostgroup', 'HOST', [hostname, "|".join(hostgroups)])
+        return self.webservice.call_clapi('delhostgroup', self.clapi_object, [hostname, "|".join(hostgroups)])
 
     def setseverity(self, hostname, name):
-        return self.webservice.call_clapi('setseverity', 'HOST', [hostname, name    ])
+        return self.webservice.call_clapi('setseverity', self.clapi_object, [hostname, name    ])
 
     def unsetseverity(self, hostname):
-        return self.webservice.call_clapi('unsetseverity', 'HOST', hostname)
+        return self.webservice.call_clapi('unsetseverity', self.clapi_object, hostname)
 
     def enable(self, hostname):
-        return self.webservice.call_clapi('enable', 'HOST', hostname)
+        return self.webservice.call_clapi('enable', self.clapi_object, hostname)
 
     def disable(self, hostname):
-        return self.webservice.call_clapi('disable', 'HOST', hostname)
-
-
-
+        return self.webservice.call_clapi('disable', self.clapi_object, hostname)

--- a/centreonapi/webservice/configuration/host_template.py
+++ b/centreonapi/webservice/configuration/host_template.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+from centreonapi.webservice import Webservice
+from centreonapi.webservice.configuration.host import *
+
+class HostTemplateObj(HostObj):
+    pass
+
+class HostTemplate(Host):
+    """
+    Centreon Web host object
+    """
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.webservice = Webservice.getInstance()
+        self.clapi_object = 'HTPL'
+
+    def add(self, hostname, hostalias, hostip, hosttemplate, pollername=None, hgname=None):
+        """
+        Add a host template
+        """
+        return super(HostTemplate, self).add(hostname, hostalias, hostip, hosttemplate, '', [])
+
+    def setinstance(self, hostname, instance):
+        pass
+
+    def applytemplate(self, hostname):
+        pass
+
+    def getparent(self, hostname):
+        pass
+
+    def addparent(self, hostname, parents):
+        pass
+
+    def setparent(self, hostname, parents):
+        pass
+
+    def deleteparent(self, hostname, parents):
+        pass
+
+    def gethostgroup(self, hostname):
+        pass
+
+    def addhostgroup(self, hostname, hostgroups):
+        pass
+
+    def sethostgroup(self, hostname, hostgroups):
+        pass
+
+    def deletehostgroup(self, hostname, hostgroups):
+        pass

--- a/centreonapi/webservice/configuration/poller.py
+++ b/centreonapi/webservice/configuration/poller.py
@@ -25,6 +25,16 @@ class Poller(object):
         """
         return self.webservice.call_clapi('show', 'INSTANCE')
 
+    def show(self, pollername):
+        values = [pollername]
+        return self.webservice.call_clapi('show', 'INSTANCE', values)
+
+    def get(self, pollername):
+        list_pollers = self.show(pollername)
+        for poller in list_pollers['result']:
+            if pollername == poller['name']:
+                return poller
+
     def add(self, *args, **kwargs):
         pass
 

--- a/centreonapi/webservice/configuration/service.py
+++ b/centreonapi/webservice/configuration/service.py
@@ -9,20 +9,21 @@ class Service(object):
 
     def __init__(self):
         self.webservice = Webservice.getInstance()
+        self.clapi_object = 'SERVICE'
 
     def list(self):
-        return self.webservice.call_clapi('show', 'SERVICE')
+        return self.webservice.call_clapi('show', self.clapi_object)
 
     def add(self, hostname, servicename, template):
         values = [hostname, servicename, template]
-        return self.webservice.call_clapi('add', 'SERVICE', values)
+        return self.webservice.call_clapi('add', self.clapi_object, values)
 
     def delete(self, hostname, servicename):
-        return self.webservice.call_clapi('del', 'SERVICE', [hostname, servicename])
+        return self.webservice.call_clapi('del', self.clapi_object, [hostname, servicename])
 
     def setparam(self, hostname, servicename, name, value):
         values = [hostname, servicename, name, value]
-        return self.webservice.call_clapi('setparam', 'SERVICE', values)
+        return self.webservice.call_clapi('setparam', self.clapi_object, values)
 
     def addhost(self):
         pass
@@ -34,79 +35,79 @@ class Service(object):
         pass
 
     def getmacro(self, hostname, servicename):
-        return self.webservice.call_clapi('getmacro', 'SERVICE', [hostname,servicename])
+        return self.webservice.call_clapi('getmacro', self.clapi_object, [hostname,servicename])
 
     def setmacro(self, hostname, servicename, name, value, description):
         values = [hostname, servicename, name, value, description]
-        return self.webservice.call_clapi('setmacro', 'SERVICE', values)
+        return self.webservice.call_clapi('setmacro', self.clapi_object, values)
 
     def delmacro(self, hostname, servicename, name):
         values = [hostname, servicename, name ]
-        return self.webservice.call_clapi('delmacro', 'SERVICE', values)
+        return self.webservice.call_clapi('delmacro', self.clapi_object, values)
 
     def setseverity(self, hostname, servicename, name):
         values = [hostname, servicename, name ]
-        return self.webservice.call_clapi('setseverity', 'SERVICE', values)
+        return self.webservice.call_clapi('setseverity', self.clapi_object, values)
 
     def unsetseverity(self, hostname, servicename):
         values = [hostname, servicename]
-        return self.webservice.call_clapi('unsetseverity', 'SERVICE', values)
+        return self.webservice.call_clapi('unsetseverity', self.clapi_object, values)
 
     def getcontact(self, hostname, servicename):
         values = [hostname, servicename]
-        return self.webservice.call_clapi('getcontact', 'SERVICE', values)
+        return self.webservice.call_clapi('getcontact', self.clapi_object, values)
 
     def addcontact(self, hostname, servicename, contact):
         values = [hostname, servicename, contact]
-        return self.webservice.call_clapi('addcontact', 'SERVICE', values)
+        return self.webservice.call_clapi('addcontact', self.clapi_object, values)
 
     def setcontact(self, hostname, servicename, contact):
         values = [hostname, servicename, '|'.join(contact)]
-        return self.webservice.call_clapi('setcontact', 'SERVICE', values)
+        return self.webservice.call_clapi('setcontact', self.clapi_object, values)
 
     def delcontact(self, hostname, servicename, contact):
         try:
             for i in contact:
                 values = [hostname, servicename, i]
-                self.webservice.call_clapi('delcontact', 'SERVICE', values)
+                self.webservice.call_clapi('delcontact', self.clapi_object, values)
             return True
         except Exception:
             return False
 
     def getcontactgroup(self, hostname, servicename):
         values = [hostname, servicename]
-        return self.webservice.call_clapi('getcontactgroup', 'SERVICE', values)
+        return self.webservice.call_clapi('getcontactgroup', self.clapi_object, values)
 
     def setcontactgroup(self, hostname, servicename, contact):
         values = [hostname, servicename, '|'.join(contact)]
-        return self.webservice.call_clapi('setcontactgroup', 'SERVICE', values)
+        return self.webservice.call_clapi('setcontactgroup', self.clapi_object, values)
 
     def delcontactgroup(self, hostname, servicename, contact):
         try:
             for i in contact:
                 values = [hostname, servicename, i]
-                self.webservice.call_clapi('delcontactgroup', 'SERVICE', values)
+                self.webservice.call_clapi('delcontactgroup', self.clapi_object, values)
             return True
         except Exception:
             return False
 
     def gettrap(self, hostname, servicename):
         values = [hostname, servicename]
-        return self.webservice.call_clapi('gettrap', 'SERVICE', values)
+        return self.webservice.call_clapi('gettrap', self.clapi_object, values)
 
     def addtrap(self, hostname, servicename, trap):
         values = [hostname, servicename, trap]
-        return self.webservice.call_clapi('addtrap', 'SERVICE', values)
+        return self.webservice.call_clapi('addtrap', self.clapi_object, values)
 
     def settrap(self, hostname, servicename, trap):
         values = [hostname, servicename, '|'.join(trap)]
-        return self.webservice.call_clapi('settrap', 'SERVICE', values)
+        return self.webservice.call_clapi('settrap', self.clapi_object, values)
 
     def deltrap(self, hostname, servicename, trap):
         try:
             for i in trap:
                 values = [hostname, servicename, i]
-                self.webservice.call_clapi('deltrap', 'SERVICE', values)
+                self.webservice.call_clapi('deltrap', self.clapi_object, values)
             return True
         except Exception:
             return False

--- a/centreonapi/webservice/configuration/service_template.py
+++ b/centreonapi/webservice/configuration/service_template.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+from centreonapi.webservice import Webservice
+
+class ServiceTemplate(object):
+    """
+    Centreon Web Service Template Object
+    """
+
+    def __init__(self):
+        self.webservice = Webservice.getInstance()
+        self.clapi_object = 'STPL'
+
+    def list(self):
+        return self.webservice.call_clapi('show', self.clapi_object)
+
+    def add(self, servicedescription, servicename, template):
+        values = [servicedescription, servicename, template]
+        return self.webservice.call_clapi('add', self.clapi_object, values)
+
+    def delete(self, servicename):
+        return self.webservice.call_clapi('del', self.clapi_object, [servicename])
+
+    def setparam(self, servicename, name, value):
+        values = [servicename, name, value]
+        return self.webservice.call_clapi('setparam', self.clapi_object, values)
+
+    def addhosttemplate(self, servicename, hosttemplate):
+        values = [servicename, '|'.join(hosttemplate)]
+        return self.webservice.call_clapi('addhosttemplate', self.clapi_object, values)
+
+    def sethosttemplate(self, servicename, hosttemplate):
+        values = [servicename, '|'.join(hosttemplate)]
+        return self.webservice.call_clapi('sethosttemplate', self.clapi_object, values)
+
+    def delhosttemplate(self, servicename, hosttemplate):
+        values = [servicename, '|'.join(hosttemplate)]
+        return self.webservice.call_clapi('delhosttemplate', self.clapi_object, values)
+
+    def getmacro(self, servicename):
+        return self.webservice.call_clapi('getmacro', self.clapi_object, [hostname,servicename])
+
+    def setmacro(self, servicename, name, value, description):
+        values = [servicename, name, value, description]
+        return self.webservice.call_clapi('setmacro', self.clapi_object, values)
+
+    def delmacro(self, servicename, name):
+        values = [servicename, name ]
+        return self.webservice.call_clapi('delmacro', self.clapi_object, values)
+
+    def getcontact(self, servicename):
+        values = [servicename]
+        return self.webservice.call_clapi('getcontact', self.clapi_object, values)
+
+    def addcontact(self, servicename, contact):
+        values = [servicename, contact]
+        return self.webservice.call_clapi('addcontact', self.clapi_object, values)
+
+    def setcontact(self, servicename, contact):
+        values = [servicename, '|'.join(contact)]
+        return self.webservice.call_clapi('setcontact', self.clapi_object, values)
+
+    def delcontact(self, servicename, contact):
+        try:
+            for i in contact:
+                values = [servicename, i]
+                self.webservice.call_clapi('delcontact', self.clapi_object, values)
+            return True
+        except Exception:
+            return False
+
+    def getcontactgroup(self, servicename):
+        values = [servicename]
+        return self.webservice.call_clapi('getcontactgroup', self.clapi_object, values)
+
+    def setcontactgroup(self, servicename, contact):
+        values = [servicename, '|'.join(contact)]
+        return self.webservice.call_clapi('setcontactgroup', self.clapi_object, values)
+
+    def delcontactgroup(self, servicename, contact):
+        try:
+            for i in contact:
+                values = [servicename, i]
+                self.webservice.call_clapi('delcontactgroup', self.clapi_object, values)
+            return True
+        except Exception:
+            return False
+
+    def gettrap(self, servicename):
+        values = [servicename]
+        return self.webservice.call_clapi('gettrap', self.clapi_object, values)
+
+    def addtrap(self, servicename, trap):
+        values = [servicename, trap]
+        return self.webservice.call_clapi('addtrap', self.clapi_object, values)
+
+    def settrap(self, servicename, trap):
+        values = [servicename, '|'.join(trap)]
+        return self.webservice.call_clapi('settrap', self.clapi_object, values)
+
+    def deltrap(self, servicename, trap):
+        try:
+            for i in trap:
+                values = [servicename, i]
+                self.webservice.call_clapi('deltrap', self.clapi_object, values)
+            return True
+        except Exception:
+            return False

--- a/centreonapi/webservice/configuration/service_template.py
+++ b/centreonapi/webservice/configuration/service_template.py
@@ -2,6 +2,29 @@
 
 from centreonapi.webservice import Webservice
 
+class ServiceTemplateObj(object):
+
+    def __init__(self, properties):
+        self.description = properties['description']
+        self.alias = properties['alias']
+        self.command = properties['check command']
+        self.command_args = properties['check command arg']
+        self.active = properties['active checks enabled']
+        self.passive = properties['passive checks enabled']
+        self.max_attempts = properties['max check attempts']
+        self.interval = properties['normal check interval']
+        self.retry_interval = properties['retry check interval']
+
+    def description(self):
+        return self.description
+
+    def address(self):
+        return self.address()
+
+    def alias(self):
+        return self.alias()
+
+
 class ServiceTemplate(object):
     """
     Centreon Web Service Template Object
@@ -13,6 +36,16 @@ class ServiceTemplate(object):
 
     def list(self):
         return self.webservice.call_clapi('show', self.clapi_object)
+
+    def show(self, servicedescription):
+        values = [servicedescription]
+        return self.webservice.call_clapi('show', self.clapi_object, values)
+
+    def get(self, servicedescription):
+        list_service = self.show(servicedescription)
+        for service in list_service['result']:
+            if servicedescription == service['description']:
+                return ServiceTemplateObj(service)
 
     def add(self, servicedescription, servicename, template):
         values = [servicedescription, servicename, template]


### PR DESCRIPTION
This PR add bindings for host template and service template CLAPI APIs.

In addition we expose systematically `show()` and `get()` methods for every object type.

We did those additions to extend [guillaumewatteeux/ansible-centreon](https://github.com/guillaumewatteeux/ansible-centreon) Ansible modules to support acting on host template and service template objects and reloading pollers.

Here is a link to our forked version of the Ansible modules that we wish to propose to merge with the original source eventually: [Transatel/ansible-centreon](https://github.com/Transatel/ansible-centreon)